### PR TITLE
Support NiFi 2.x

### DIFF
--- a/nifi-daffodil-processors/src/main/java/com/owlcyberdefense/nifi/processors/DaffodilParse.java
+++ b/nifi-daffodil-processors/src/main/java/com/owlcyberdefense/nifi/processors/DaffodilParse.java
@@ -24,7 +24,6 @@ import java.io.Writer;
 import java.nio.channels.Channels;
 import java.nio.channels.ReadableByteChannel;
 
-import org.apache.nifi.annotation.behavior.EventDriven;
 import org.apache.nifi.annotation.behavior.DynamicProperty;
 import org.apache.nifi.annotation.behavior.InputRequirement;
 import org.apache.nifi.annotation.behavior.InputRequirement.Requirement;
@@ -46,7 +45,6 @@ import org.apache.daffodil.japi.infoset.JsonInfosetOutputter;
 import org.apache.daffodil.japi.infoset.XMLTextInfosetOutputter;
 
 
-@EventDriven
 @SideEffectFree
 @SupportsBatching
 @InputRequirement(Requirement.INPUT_REQUIRED)
@@ -64,8 +62,8 @@ public class DaffodilParse extends AbstractDaffodilProcessor {
 
     private InfosetOutputter getInfosetOutputter(String infosetType, OutputStream os) {
         switch (infosetType) {
-            case XML_VALUE: return new XMLTextInfosetOutputter(os, false);
-            case JSON_VALUE: return new JsonInfosetOutputter(os, false);
+            case INFOSET_TYPE_XML: return new XMLTextInfosetOutputter(os, false);
+            case INFOSET_TYPE_JSON: return new JsonInfosetOutputter(os, false);
             default: throw new AssertionError("Unhandled infoset type: " + infosetType);
         }
     }
@@ -76,8 +74,8 @@ public class DaffodilParse extends AbstractDaffodilProcessor {
     @Override
     protected String getOutputMimeType(String infosetType) {
         switch (infosetType) {
-            case XML_VALUE: return XML_MIME_TYPE;
-            case JSON_VALUE: return JSON_MIME_TYPE;
+            case INFOSET_TYPE_XML: return XML_MIME_TYPE;
+            case INFOSET_TYPE_JSON: return JSON_MIME_TYPE;
             default: throw new AssertionError("Unhandled infoset type: " + infosetType);
         }
     }

--- a/nifi-daffodil-processors/src/main/java/com/owlcyberdefense/nifi/processors/DaffodilUnparse.java
+++ b/nifi-daffodil-processors/src/main/java/com/owlcyberdefense/nifi/processors/DaffodilUnparse.java
@@ -24,7 +24,6 @@ import java.io.Reader;
 import java.nio.channels.Channels;
 import java.nio.channels.WritableByteChannel;
 
-import org.apache.nifi.annotation.behavior.EventDriven;
 import org.apache.nifi.annotation.behavior.DynamicProperty;
 import org.apache.nifi.annotation.behavior.InputRequirement;
 import org.apache.nifi.annotation.behavior.InputRequirement.Requirement;
@@ -43,7 +42,6 @@ import org.apache.daffodil.japi.infoset.InfosetInputter;
 import org.apache.daffodil.japi.infoset.JsonInfosetInputter;
 import org.apache.daffodil.japi.infoset.XMLTextInfosetInputter;
 
-@EventDriven
 @SideEffectFree
 @SupportsBatching
 @InputRequirement(Requirement.INPUT_REQUIRED)
@@ -61,8 +59,8 @@ public class DaffodilUnparse extends AbstractDaffodilProcessor {
 
     private InfosetInputter getInfosetInputter(String infosetType, InputStream is) {
         switch (infosetType) {
-            case XML_VALUE: return new XMLTextInfosetInputter(is);
-            case JSON_VALUE: return new JsonInfosetInputter(is);
+            case INFOSET_TYPE_XML: return new XMLTextInfosetInputter(is);
+            case INFOSET_TYPE_JSON: return new JsonInfosetInputter(is);
             default: throw new AssertionError("Unhandled infoset type: " + infosetType);
         }
     }

--- a/nifi-daffodil-processors/src/main/resources/docs/com.owlcyberdefense.nifi.processors.DaffodilParse/additionalDetails.html
+++ b/nifi-daffodil-processors/src/main/resources/docs/com.owlcyberdefense.nifi.processors.DaffodilParse/additionalDetails.html
@@ -137,7 +137,7 @@ Pre-compiled Schema: true
         <dd>
             <p>
             Cached compiled DFDL schemas that go unused for a specified amount of time are removed from the cache to
-            save memory. This time is defind by the <tt>Cache TTL after last access</tt> property, with the format of
+            save memory. This time is defined by the <tt>Cache TTL after last access</tt> property, with the format of
             <tt>&lt;duration&gt; &lt;time_unit&gt;</tt>, where <tt>&lt;duration&gt;</tt> is a non-negative integer and
             <tt>&lt;time_unit&gt;</tt> is a supported unit of time, such as nanos, millis, secs, mins, hrs, days. The
             default is "0 seconds", which means compiled DFDL schemas are never removed from the cache.
@@ -151,6 +151,24 @@ Pre-compiled Schema: true
 </p>
 <p>
 Restart the processor to manually empty the cache and recompile/reload schemas as needed.
+</p>
+
+<h2>Infoset Types</h2>
+<p>
+This processor supports parsing to XML and JSON infosets as specified by the <tt>Infoset Type</tt>
+property, which can be either <tt>xml</tt> or <tt>json</tt>. If the parse is successful, the
+<tt>mime.type</tt> attribute is set to <tt>application/xml</tt> or <tt>application/json</tt>
+accordingly.
+</p>
+
+<h2>Validation Mode</h2>
+<p>
+The DaffodilParse processor can optionally enable validation of the infoset. A value of
+<tt>limited</tt> uses Daffodil's built-in validation mechanism. A value of <tt>full</tt> enables XSD
+validation using Apache Xerces. A value of <tt>off</tt> disables validation.
+</p>
+<p>If validation is enabled (either <tt>limited</tt> or <tt>full</tt>) and any validation errors are
+found, the FlowFile is transferred to the <i>failure</i> relationship.
 </p>
 
 </body>

--- a/nifi-daffodil-processors/src/main/resources/docs/com.owlcyberdefense.nifi.processors.DaffodilUnparse/additionalDetails.html
+++ b/nifi-daffodil-processors/src/main/resources/docs/com.owlcyberdefense.nifi.processors.DaffodilUnparse/additionalDetails.html
@@ -138,7 +138,7 @@ Pre-compiled Schema: true
         <dd>
             <p>
             Cached compiled DFDL schemas that go unused for a specified amount of time are removed from the cache to
-            save memory. This time is defind by the <tt>Cache TTL after last access</tt> property, with the format of
+            save memory. This time is defined by the <tt>Cache TTL after last access</tt> property, with the format of
             <tt>&lt;duration&gt; &lt;time_unit&gt;</tt>, where <tt>&lt;duration&gt;</tt> is a non-negative integer and
             <tt>&lt;time_unit&gt;</tt> is a supported unit of time, such as nanos, millis, secs, mins, hrs, days. The
             default is "0 seconds", which means compiled DFDL schemas are never removed from the cache.
@@ -152,6 +152,20 @@ Pre-compiled Schema: true
 </p>
 <p>
 Restart the processor to manually empty the cache and recompile/reload schemas as needed.
+</p>
+
+<h2>Infoset Types</h2>
+<p>
+This processor supports unparsing XML and JSON infosets as specified by the <tt>Infoset Type</tt>
+property. Alternatively, the property can be set so that the processor uses the <tt>mime.type</tt>
+attribute. In this case, an attribute value of <tt>application/xml</tt> or <tt>application/json</tt>
+will cause the processor to expect an XML or JSON infoset respectively. Note that the DaffodilParse
+processor sets the <tt>mime.type</tt> attribute based its <tt>Infoset Type</tt> property.
+</p>
+
+<h2>Validation Mode</h2>
+<p>
+The DaffodilUnparse processor ignores the validation mode setting. Future versions may enable this.
 </p>
 
 </body>

--- a/nifi-daffodil-processors/src/test/java/com/owlcyberdefense/nifi/processors/TestDaffodilProcessor.java
+++ b/nifi-daffodil-processors/src/test/java/com/owlcyberdefense/nifi/processors/TestDaffodilProcessor.java
@@ -197,7 +197,7 @@ public class TestDaffodilProcessor {
     public void testParseCSVJson() throws IOException {
         final TestRunner testRunner = TestRunners.newTestRunner(DaffodilParse.class);
         testRunner.setProperty(DaffodilParse.DFDL_SCHEMA_FILE, "src/test/resources/TestDaffodilProcessor/csv.dfdl.xsd");
-        testRunner.setProperty("infoset-type", DaffodilParse.JSON_VALUE);
+        testRunner.setProperty("infoset-type", DaffodilParse.INFOSET_TYPE_JSON);
         testRunner.enqueue(Paths.get("src/test/resources/TestDaffodilProcessor/tokens.csv"));
         testRunner.run();
         testRunner.assertAllFlowFilesTransferred(DaffodilParse.REL_SUCCESS);
@@ -211,7 +211,7 @@ public class TestDaffodilProcessor {
     public void testUnparseCSVJson() throws IOException {
         final TestRunner testRunner = TestRunners.newTestRunner(DaffodilUnparse.class);
         testRunner.setProperty(DaffodilUnparse.DFDL_SCHEMA_FILE, "src/test/resources/TestDaffodilProcessor/csv.dfdl.xsd");
-        testRunner.setProperty("infoset-type", DaffodilUnparse.JSON_VALUE);
+        testRunner.setProperty("infoset-type", DaffodilUnparse.INFOSET_TYPE_JSON);
         final Map<String, String> attributes = new HashMap<>();
         attributes.put(CoreAttributes.MIME_TYPE.key(), DaffodilUnparse.JSON_MIME_TYPE);
         testRunner.enqueue(Paths.get("src/test/resources/TestDaffodilProcessor/tokens.csv.json"), attributes);
@@ -227,7 +227,7 @@ public class TestDaffodilProcessor {
     public void testParseCSVAttributeInvalid() throws IOException {
         final TestRunner testRunner = TestRunners.newTestRunner(DaffodilParse.class);
         testRunner.setProperty(DaffodilParse.DFDL_SCHEMA_FILE, "src/test/resources/TestDaffodilProcessor/csv.dfdl.xsd");
-        testRunner.setProperty("infoset-type", DaffodilParse.ATTRIBUTE_VALUE);
+        testRunner.setProperty("infoset-type", DaffodilParse.INFOSET_TYPE_ATTRIBUTE);
         testRunner.assertNotValid();
     }
 
@@ -235,7 +235,7 @@ public class TestDaffodilProcessor {
     public void testUnparseCSVAttributeJSON() throws IOException {
         final TestRunner testRunner = TestRunners.newTestRunner(DaffodilUnparse.class);
         testRunner.setProperty(DaffodilUnparse.DFDL_SCHEMA_FILE, "src/test/resources/TestDaffodilProcessor/csv.dfdl.xsd");
-        testRunner.setProperty("infoset-type", DaffodilUnparse.ATTRIBUTE_VALUE);
+        testRunner.setProperty("infoset-type", DaffodilUnparse.INFOSET_TYPE_ATTRIBUTE);
         final Map<String, String> attributes = new HashMap<>();
         attributes.put(CoreAttributes.MIME_TYPE.key(), DaffodilUnparse.JSON_MIME_TYPE);
         testRunner.enqueue(Paths.get("src/test/resources/TestDaffodilProcessor/tokens.csv.json"), attributes);
@@ -251,7 +251,7 @@ public class TestDaffodilProcessor {
     public void testUnparseCSVAttributeXML() throws IOException {
         final TestRunner testRunner = TestRunners.newTestRunner(DaffodilUnparse.class);
         testRunner.setProperty(DaffodilUnparse.DFDL_SCHEMA_FILE, "src/test/resources/TestDaffodilProcessor/csv.dfdl.xsd");
-        testRunner.setProperty("infoset-type", DaffodilUnparse.ATTRIBUTE_VALUE);
+        testRunner.setProperty("infoset-type", DaffodilUnparse.INFOSET_TYPE_ATTRIBUTE);
         final Map<String, String> attributes = new HashMap<>();
         attributes.put(CoreAttributes.MIME_TYPE.key(), DaffodilUnparse.XML_MIME_TYPE);
         testRunner.enqueue(Paths.get("src/test/resources/TestDaffodilProcessor/tokens.csv.xml"), attributes);
@@ -267,7 +267,7 @@ public class TestDaffodilProcessor {
     public void testUnparseCSVAttributeUndefined() throws IOException {
         final TestRunner testRunner = TestRunners.newTestRunner(DaffodilUnparse.class);
         testRunner.setProperty(DaffodilUnparse.DFDL_SCHEMA_FILE, "src/test/resources/TestDaffodilProcessor/csv.dfdl.xsd");
-        testRunner.setProperty("infoset-type", DaffodilUnparse.ATTRIBUTE_VALUE);
+        testRunner.setProperty("infoset-type", DaffodilUnparse.INFOSET_TYPE_ATTRIBUTE);
         final Map<String, String> attributes = new HashMap<>();
         testRunner.enqueue(Paths.get("src/test/resources/TestDaffodilProcessor/tokens.csv.xml"), attributes);
         testRunner.run();
@@ -281,7 +281,7 @@ public class TestDaffodilProcessor {
     public void testUnparseCSVAttributeUnknown() throws IOException {
         final TestRunner testRunner = TestRunners.newTestRunner(DaffodilUnparse.class);
         testRunner.setProperty(DaffodilUnparse.DFDL_SCHEMA_FILE, "src/test/resources/TestDaffodilProcessor/csv.dfdl.xsd");
-        testRunner.setProperty("infoset-type", DaffodilUnparse.ATTRIBUTE_VALUE);
+        testRunner.setProperty("infoset-type", DaffodilUnparse.INFOSET_TYPE_ATTRIBUTE);
         final Map<String, String> attributes = new HashMap<>();
         attributes.put(CoreAttributes.MIME_TYPE.key(), "application/unknown");
         testRunner.enqueue(Paths.get("src/test/resources/TestDaffodilProcessor/tokens.csv.xml"), attributes);
@@ -321,7 +321,7 @@ public class TestDaffodilProcessor {
     public void testParseCSVValidationLimited() throws IOException {
         final TestRunner testRunner = TestRunners.newTestRunner(DaffodilParse.class);
         testRunner.setProperty(DaffodilParse.DFDL_SCHEMA_FILE, "src/test/resources/TestDaffodilProcessor/csv.dfdl.xsd");
-        testRunner.setProperty(DaffodilParse.VALIDATION_MODE, DaffodilParse.LIMITED_VALUE);
+        testRunner.setProperty(DaffodilParse.VALIDATION_MODE, DaffodilParse.VALIDATION_MODE_LIMITED);
         testRunner.enqueue(Paths.get("src/test/resources/TestDaffodilProcessor/tokens.csv"));
         testRunner.run();
         testRunner.assertAllFlowFilesTransferred(DaffodilParse.REL_FAILURE);
@@ -334,7 +334,7 @@ public class TestDaffodilProcessor {
     public void testParseCSVValidationFull() throws IOException {
         final TestRunner testRunner = TestRunners.newTestRunner(DaffodilParse.class);
         testRunner.setProperty(DaffodilParse.DFDL_SCHEMA_FILE, "src/test/resources/TestDaffodilProcessor/csv.dfdl.xsd");
-        testRunner.setProperty(DaffodilParse.VALIDATION_MODE, DaffodilParse.FULL_VALUE);
+        testRunner.setProperty(DaffodilParse.VALIDATION_MODE, DaffodilParse.VALIDATION_MODE_FULL);
         testRunner.enqueue(Paths.get("src/test/resources/TestDaffodilProcessor/tokens.csv"));
         testRunner.run();
         testRunner.assertAllFlowFilesTransferred(DaffodilParse.REL_FAILURE);


### PR DESCRIPTION
The latest versions of NiFi change/remove API functions that are used by the Daffodil processors. Trying to use the current version of these processors in newer versions of Daffodil leads to NoClassDefFoundErrors and breaks NiFi.

To fix this, this replaces those API functions/classes with variants that exist in both older and newer versions of NiFi. This allows this processor to maintain compatibility with older versions of NiFi while still working with newer versions.

Specific changes include:

- NiFi 2.x removes support for EventDriven processors. This is likely rarely used in NiFi 1.x flows so support for EventDriven is removed for DaffodilParse/Unparse processors
- NiFi 2.x replaces the allowableValues(AllowableValues...) function with allowableValues(DescribedValue...). The DescribedValue variant does not exist in older versions of NiFi, so we instead just use the allowableValues(String...) variant, which exists in all versions of NiFi. This loses the human readable description of the field, but the allowable values are mostly self-descriptive. And in case there is still confusion, descriptions of the possible values are added to additionalDetails.html

Closes #18